### PR TITLE
Fix broken links in readme, docs and missing features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,7 @@ required-features = ["std"]
 name = "benchmarks"
 harness = false
 required-features = ["std"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Consider reading the [User Guide](https://ten3roberts.github.io/flax/guide)
 ## Features
 
 - [Declarative component macro](https://docs.rs/flax/latest/flax/macro.component.html)
-- [Expressive query system](https://docs.rs/flax/latest/flax/struct.Query.html)
-- [Change detection](https://docs.rs/flax/latest/flax/struct.Component.html#method.modified)
+- [Expressive query system](https://docs.rs/flax/latest/flax/query/struct.Query.html)
+- [Change detection](https://docs.rs/flax/latest/flax/component/struct.Component.html#method.modified)
 - [Query filtering](https://docs.rs/flax/latest/flax/filter/index.html)
 - [System execution](https://docs.rs/flax/latest/flax/system/struct.System.html)
 - [Multithreaded system execution](https://docs.rs/flax/latest/flax/schedule/struct.Schedule.html)
 - [Many to many entity relation and graphs](https://docs.rs/flax/latest/flax/macro.component.html#relations)
 - [Reflection through component metadata](https://docs.rs/flax/latest/flax/macro.component.html)
-- [Ergonomic entity builder](https://docs.rs/flax/latest/flax/struct.EntityBuilder.html)
+- [Ergonomic entity builder](https://docs.rs/flax/latest/flax/entity/struct.EntityBuilder.html)
 - [Serialization and deserialization](https://docs.rs/flax/latest/flax/serialize/)
-- [(async) event subscription](https://docs.rs/flax/latest/flax/struct.World.html#method.subscribe)
-- [Runtime components](https://docs.rs/flax/latest/flax/struct.World.html#method.spawn_component)
+- [(async) event subscription](https://docs.rs/flax/latest/flax/world/struct.World.html#method.subscribe)
+- [Runtime components](https://docs.rs/flax/latest/flax/world/struct.World.html#method.spawn_component)
 - ...and more
 
 ## [Live Demo](https://ten3roberts.github.io/flax/asteroids)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::redundant_explicit_links)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate alloc;
 
@@ -280,5 +281,6 @@ pub use world::World;
 pub(crate) use query::ArchetypeSearcher;
 pub(crate) use vtable::ComponentVTable;
 
+#[doc(inline)]
 #[cfg(feature = "derive")]
 pub use flax_derive::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,17 @@
 //! ## Features
 //!
 //! - [Declarative component macro](https://docs.rs/flax/latest/flax/macro.component.html)
-//! - [Queries](https://docs.rs/flax/latest/flax/struct.Query.html)
-//! - [Change detection](https://docs.rs/flax/latest/flax/struct.Component.html#method.modified)
+//! - [Expressive query system](https://docs.rs/flax/latest/flax/query/struct.Query.html)
+//! - [Change detection](https://docs.rs/flax/latest/flax/component/struct.Component.html#method.modified)
 //! - [Query filtering](https://docs.rs/flax/latest/flax/filter/index.html)
 //! - [System execution](https://docs.rs/flax/latest/flax/system/struct.System.html)
 //! - [Multithreaded system execution](https://docs.rs/flax/latest/flax/schedule/struct.Schedule.html)
 //! - [Many to many entity relation and graphs](https://docs.rs/flax/latest/flax/macro.component.html#relations)
 //! - [Reflection through component metadata](https://docs.rs/flax/latest/flax/macro.component.html)
-//! - [Ergonomic entity builder](https://docs.rs/flax/latest/flax/struct.EntityBuilder.html)
+//! - [Ergonomic entity builder](https://docs.rs/flax/latest/flax/entity/struct.EntityBuilder.html)
 //! - [Serialization and deserialization](https://docs.rs/flax/latest/flax/serialize/)
-//! - [(async) event subscription](https://docs.rs/flax/latest/flax/struct.World.html#method.subscribe)
-//! - [Runtime components](https://docs.rs/flax/latest/flax/struct.World.html#method.spawn_component)
+//! - [(async) event subscription](https://docs.rs/flax/latest/flax/world/struct.World.html#method.subscribe)
+//! - [Runtime components](https://docs.rs/flax/latest/flax/world/struct.World.html#method.spawn_component)
 //! - ...and more
 //!
 //! ## [Live Demo](https://ten3roberts.github.io/flax/asteroids)


### PR DESCRIPTION
* Fix some doc links missing a path component
* Tell rustdoc to document all features and show the "available on feature" box, see https://github.com/rust-lang/cargo/issues/8103 (previously `flax::serialize` and `derive` were missing from the docs)