### PR TITLE
feat: add support for .removed() filters with cross-archetype tracking

### DIFF
--- a/src/archetype/changes.rs
+++ b/src/archetype/changes.rs
@@ -534,6 +534,12 @@ impl Changes {
         self
     }
 
+    #[inline]
+    pub(crate) fn set_removed(&mut self, change: Change) -> &mut Self {
+        self.map[ChangeKind::Removed as usize].set(change);
+        self
+    }
+
     /// Removes `src` by swapping `dst` into its place
     pub(crate) fn swap_remove(
         &mut self,

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -132,7 +132,9 @@ impl CellData {
     }
 
     #[inline]
-    pub(crate) fn set_removed(&mut self, ids: &[Entity], slots: Slice) {
+    pub(crate) fn set_removed(&mut self, ids: &[Entity], slots: Slice, change_tick: u32) {
+        self.changes.set_removed(Change::new(slots, change_tick));
+
         let event = EventData {
             ids,
             slots,
@@ -315,6 +317,33 @@ pub struct Archetype {
     pub(crate) children: BTreeMap<ComponentKey, ArchetypeId>,
     pub(crate) outgoing: BTreeMap<ComponentKey, ArchetypeId>,
     pub(crate) incoming: BTreeMap<ComponentKey, ArchetypeId>,
+
+    /// Tracks removal events for components that don't exist in this archetype
+    /// Used for cross-archetype change tracking
+    external_removals: BTreeMap<ComponentKey, ExternalRemovalData>,
+}
+
+/// Tracks removal events for components that don't physically exist in this archetype
+/// but need to be tracked for cross-archetype change detection
+pub(crate) struct ExternalRemovalData {
+    changes: Changes,
+}
+
+impl ExternalRemovalData {
+    pub(crate) fn new(_key: ComponentKey) -> Self {
+        Self {
+            changes: Changes::new(),
+        }
+    }
+
+    pub(crate) fn record_removal(&mut self, _entity: Entity, entity_slot: Slot, change_tick: u32) {
+        // Record the removal change for this slot
+        self.changes.set_removed(Change::new(Slice::single(entity_slot), change_tick));
+    }
+
+    pub(crate) fn changes(&self) -> &Changes {
+        &self.changes
+    }
 }
 
 /// Since all components are Send + Sync, the cells are as well
@@ -330,6 +359,7 @@ impl Archetype {
             entities: Vec::new(),
             children: Default::default(),
             outgoing: Default::default(),
+            external_removals: BTreeMap::new(),
         }
     }
 
@@ -352,6 +382,7 @@ impl Archetype {
             entities: Vec::new(),
             children: Default::default(),
             outgoing: Default::default(),
+            external_removals: BTreeMap::new(),
         }
     }
 
@@ -678,6 +709,7 @@ impl Archetype {
         &mut self,
         dst: &mut Self,
         slot: Slot,
+        change_tick: u32,
         mut on_drop: impl FnMut(ComponentDesc, *mut u8),
     ) -> (Slot, Option<(Entity, Slot)>) {
         let id = self.entity(slot).expect("Invalid entity");
@@ -694,7 +726,11 @@ impl Archetype {
                 cell.move_to(slot, dst_cell, dst_slot);
             } else {
                 // Notify the subscribers that the component was removed
-                data.set_removed(&[id], Slice::single(slot));
+                data.set_removed(&[id], Slice::single(slot), change_tick);
+
+                // CROSS-ARCHETYPE TRACKING: Also record the removal on the destination archetype
+                // This allows queries on the destination archetype to detect the removal
+                dst.record_external_removal(key, id, dst_slot, change_tick);
 
                 cell.take(slot, &mut on_drop);
             }
@@ -716,6 +752,7 @@ impl Archetype {
     pub unsafe fn take(
         &mut self,
         slot: Slot,
+        change_tick: u32,
         mut on_move: impl FnMut(ComponentDesc, *mut u8),
     ) -> Option<(Entity, Slot)> {
         let id = self.entity(slot).expect("Invalid entity");
@@ -727,7 +764,7 @@ impl Archetype {
         for cell in &mut *self.cells {
             let data = cell.data.get_mut();
             // data.on_event(&self.entities, Slice::single(slot), EventKind::Removed);
-            data.set_removed(&[id], Slice::single(slot));
+            data.set_removed(&[id], Slice::single(slot), change_tick);
 
             cell.take(slot, &mut on_move)
         }
@@ -743,11 +780,12 @@ impl Archetype {
     /// the `on_take` function.
     pub(crate) unsafe fn pop_last(
         &mut self,
+        change_tick: u32,
         on_take: impl FnMut(ComponentDesc, *mut u8),
     ) -> Option<Entity> {
         let last = self.last();
         if let Some(last) = last {
-            self.take(self.len() - 1, on_take);
+            self.take(self.len() - 1, change_tick, on_take);
             Some(last)
         } else {
             None
@@ -796,7 +834,7 @@ impl Archetype {
                 // unsafe { dst.storage.get_mut().append(storage) }
             } else {
                 // Notify the subscribers that the component was removed
-                data.set_removed(&entities[slots.as_range()], slots);
+                data.set_removed(&entities[slots.as_range()], slots, 0);
 
                 cell.clear();
             }
@@ -829,7 +867,7 @@ impl Archetype {
             let data = cell.data.get_mut();
             // Notify the subscribers that the component was removed
             // data.on_event(&self.entities, slots, EventKind::Removed);
-            data.set_removed(&self.entities[slots.as_range()], slots);
+            data.set_removed(&self.entities[slots.as_range()], slots, 0);
 
             cell.clear()
         }
@@ -879,7 +917,7 @@ impl Archetype {
         let slots = self.slots();
         for cell in &mut *self.cells {
             let data = cell.data.get_mut();
-            data.set_removed(&self.entities[slots.as_range()], slots)
+            data.set_removed(&self.entities[slots.as_range()], slots, 0)
         }
 
         ArchetypeDrain {
@@ -888,8 +926,31 @@ impl Archetype {
         }
     }
 
+    /// Record a removal event for a component that doesn't exist in this archetype.
+    /// This is used for cross-archetype change tracking where an entity moved here
+    /// due to a component being removed from its previous archetype.
+    pub(crate) fn record_external_removal(
+        &mut self,
+        component_key: ComponentKey,
+        entity: Entity,
+        entity_slot: Slot,
+        change_tick: u32,
+    ) {
+        // Find or create a phantom component entry for removal tracking
+        let phantom_data = self.external_removals
+            .entry(component_key)
+            .or_insert_with(|| ExternalRemovalData::new(component_key));
+
+        phantom_data.record_removal(entity, entity_slot, change_tick);
+    }
+
     pub(crate) fn entities_mut(&mut self) -> &mut [Entity] {
         &mut self.entities
+    }
+
+    /// Get external removal data for a component that doesn't exist in this archetype
+    pub(crate) fn get_external_removal(&self, component_key: ComponentKey) -> Option<&ExternalRemovalData> {
+        self.external_removals.get(&component_key)
     }
 
     pub(crate) fn component(&self, key: ComponentKey) -> Option<ComponentDesc> {

--- a/src/fetch/ext.rs
+++ b/src/fetch/ext.rs
@@ -14,7 +14,7 @@ use super::{
     expect::Expect,
     opt::{Opt, OptOr},
     source::{FetchSource, FromRelation, Traverse},
-    transform::Added,
+    transform::{Added, Removed},
     Map, Modified, RandomFetch, Satisfied, Source, TransformFetch,
 };
 
@@ -202,6 +202,22 @@ pub trait FetchExt: Sized {
         Self: TransformFetch<Added>,
     {
         self.transform_fetch(Added)
+    }
+
+    /// Transform the fetch into a fetch where each constituent part tracks and yields for
+    /// component removal events.
+    ///
+    /// This is different from E.g; `(a().modified(), b().modified())` as it implies only when
+    /// *both* `a` and `b` are modified in the same iteration, which is seldom useful.
+    ///
+    /// This means will yield *any* of `a` *or* `b` are modified.
+    ///
+    /// Works with `opt`, `copy`, etc constituents.
+    fn removed(self) -> <Self as TransformFetch<Removed>>::Output
+    where
+        Self: TransformFetch<Removed>,
+    {
+        self.transform_fetch(Removed)
     }
     /// Map each item of the query to another type using the provided function.
     fn map<F, T>(self, func: F) -> Map<Self, F>

--- a/src/fetch/transform.rs
+++ b/src/fetch/transform.rs
@@ -32,6 +32,13 @@ impl<T: ComponentValue> TransformFetch<Added> for Component<T> {
     }
 }
 
+impl<T: ComponentValue> TransformFetch<Removed> for Component<T> {
+    type Output = ChangeFilter<T>;
+    fn transform_fetch(self, _: Removed) -> Self::Output {
+        self.into_change_filter(ChangeKind::Removed)
+    }
+}
+
 impl<T: ComponentValue> TransformFetch<Modified> for ComponentMut<T> {
     type Output = Filtered<Self, NoEntities>;
     fn transform_fetch(self, _: Modified) -> Self::Output {
@@ -42,6 +49,13 @@ impl<T: ComponentValue> TransformFetch<Modified> for ComponentMut<T> {
 impl<T: ComponentValue> TransformFetch<Added> for ComponentMut<T> {
     type Output = Filtered<Self, NoEntities>;
     fn transform_fetch(self, _: Added) -> Self::Output {
+        self.filtered(NoEntities)
+    }
+}
+
+impl<T: ComponentValue> TransformFetch<Removed> for ComponentMut<T> {
+    type Output = Filtered<Self, NoEntities>;
+    fn transform_fetch(self, _: Removed) -> Self::Output {
         self.filtered(NoEntities)
     }
 }
@@ -60,6 +74,13 @@ impl TransformFetch<Added> for EntityIds {
     }
 }
 
+impl TransformFetch<Removed> for EntityIds {
+    type Output = Filtered<Self, NoEntities>;
+    fn transform_fetch(self, _: Removed) -> Self::Output {
+        self.filtered(NoEntities)
+    }
+}
+
 /// Marker for a fetch which has been transformed to filter modified items.
 #[derive(Debug, Clone, Copy)]
 pub struct Modified;
@@ -67,6 +88,10 @@ pub struct Modified;
 /// Marker for a fetch which has been transformed to filter inserted items.
 #[derive(Debug, Clone, Copy)]
 pub struct Added;
+
+/// Marker for a fetch which has been transformed to filter removed items.
+#[derive(Debug, Clone, Copy)]
+pub struct Removed;
 
 macro_rules! tuple_impl {
     ($($idx: tt => $ty: ident),*) => {
@@ -80,6 +105,13 @@ macro_rules! tuple_impl {
         impl<$($ty: TransformFetch<Added>,)*> TransformFetch<Added> for ($($ty,)*) {
             type Output = Union<($($ty::Output,)*)>;
             fn transform_fetch(self, method: Added) -> Self::Output {
+                Union(($(self.$idx.transform_fetch(method),)*))
+            }
+        }
+
+        impl<$($ty: TransformFetch<Removed>,)*> TransformFetch<Removed> for ($($ty,)*) {
+            type Output = Union<($($ty::Output,)*)>;
+            fn transform_fetch(self, method: Removed) -> Self::Output {
                 Union(($(self.$idx.transform_fetch(method),)*))
             }
         }

--- a/src/filter/change.rs
+++ b/src/filter/change.rs
@@ -44,7 +44,17 @@ where
 
 impl<'q, T: ComponentValue> RandomFetch<'q> for PreparedChangeFilter<'_, T> {
     unsafe fn fetch_shared(&'q self, slot: Slot) -> Self::Item {
-        unsafe { self.data.get().get_unchecked(slot) }
+        match &self.data {
+            ChangeFilterData::Component(guard) => {
+                unsafe { guard.get().get_unchecked(slot) }
+            }
+            ChangeFilterData::ExternalRemoval(_) => {
+                // For external removals, we can't return actual component data
+                // This should never be called in practice for removal filters
+                // since they only use the filtering logic
+                panic!("Cannot fetch component data for removed components")
+            }
+        }
     }
 
     #[inline]
@@ -62,23 +72,48 @@ where
     type Prepared = PreparedChangeFilter<'w, T>;
 
     fn prepare(&'w self, data: FetchPrepareData<'w>) -> Option<Self::Prepared> {
-        let cell = data.arch.cell(self.component.key())?;
-        let guard = cell.borrow();
+        let cell = data.arch.cell(self.component.key());
+        
+        let filter_data = if let Some(cell) = cell {
+            // Component exists in archetype - use normal cell data
+            let guard = cell.borrow();
 
-        // Make sure to enable modification tracking if it is actively used
-        if self.kind.is_modified() {
-            guard.changes().set_track_modified()
-        }
+            // Make sure to enable modification tracking if it is actively used
+            if self.kind.is_modified() {
+                guard.changes().set_track_modified()
+            }
+
+            ChangeFilterData::Component(guard)
+        } else if matches!(self.kind, ChangeKind::Removed) {
+            // For removal filters, check if we have external removal data
+            if let Some(external_data) = data.arch.get_external_removal(self.component.key()) {
+                ChangeFilterData::ExternalRemoval(external_data)
+            } else {
+                // No external removal data available
+                return None;
+            }
+        } else {
+            // Component doesn't exist and it's not a removal filter
+            return None;
+        };
 
         Some(PreparedChangeFilter {
-            data: guard,
+            data: filter_data,
             kind: self.kind,
             cursor: ChangeCursor::new(data.old_tick),
         })
     }
 
     fn filter_arch(&self, data: FetchAccessData) -> bool {
-        self.component.filter_arch(data)
+        if matches!(self.kind, ChangeKind::Removed) {
+            // For removal filters, we want to consider all archetypes since:
+            // 1. Archetypes with the component may have normal removal tracking
+            // 2. Archetypes without the component may have external removal data
+            true
+        } else {
+            // For added/modified filters, the component must exist
+            self.component.filter_arch(data)
+        }
     }
 
     fn access(&self, data: FetchAccessData, dst: &mut Vec<Access>) {
@@ -90,7 +125,18 @@ where
     }
 
     fn searcher(&self, searcher: &mut crate::ArchetypeSearcher) {
-        searcher.add_required(self.component.key())
+        if matches!(self.kind, ChangeKind::Removed) {
+            // For removal filters, we don't add any archetype requirements
+            // since we need to check all archetypes for external removal data
+            // regardless of their component structure
+            
+            // Note: The query system's archetype caching might miss new entity locations
+            // after removals, so removal filters may need special handling to ensure
+            // all archetypes are re-checked when entities move between archetypes
+        } else {
+            // For added/modified filters, the component must be present
+            searcher.add_required(self.component.key());
+        }
     }
 }
 
@@ -141,9 +187,17 @@ impl ChangeCursor {
     }
 }
 
+/// Data source for change filtering
+enum ChangeFilterData<'w, T> {
+    /// Component exists in archetype - use normal cell data
+    Component(CellGuard<'w, [T]>),
+    /// Component doesn't exist - use external removal tracking
+    ExternalRemoval(&'w crate::archetype::ExternalRemovalData),
+}
+
 #[doc(hidden)]
 pub struct PreparedChangeFilter<'w, T> {
-    data: CellGuard<'w, [T]>,
+    data: ChangeFilterData<'w, T>,
     kind: ChangeKind,
     cursor: ChangeCursor,
 }
@@ -162,7 +216,18 @@ impl<'q, T: ComponentValue> PreparedFetch<'q> for PreparedChangeFilter<'_, T> {
     const HAS_FILTER: bool = true;
 
     unsafe fn create_chunk(&'q mut self, slots: Slice) -> Self::Chunk {
-        Ptr::new(self.data.get()[slots.as_range()].as_ptr())
+        match &self.data {
+            ChangeFilterData::Component(guard) => {
+                Ptr::new(guard.get()[slots.as_range()].as_ptr())
+            }
+            ChangeFilterData::ExternalRemoval(_) => {
+                // For external removals, we don't have actual component data
+                // We just need a dummy pointer for the filter logic
+                // This is safe because removed filters only use the change tracking data,
+                // not the actual component values
+                Ptr::new(core::ptr::null::<T>())
+            }
+        }
     }
 
     #[inline]
@@ -174,10 +239,16 @@ impl<'q, T: ComponentValue> PreparedFetch<'q> for PreparedChangeFilter<'_, T> {
 
     #[inline]
     unsafe fn filter_slots(&mut self, slots: Slice) -> Slice {
-        let cur = match self
-            .cursor
-            .find_slice(self.data.changes().get(self.kind).as_slice(), slots)
-        {
+        let changes = match &self.data {
+            ChangeFilterData::Component(guard) => {
+                guard.changes().get(self.kind).as_slice()
+            }
+            ChangeFilterData::ExternalRemoval(external_data) => {
+                external_data.changes().get(self.kind).as_slice()
+            }
+        };
+
+        let cur = match self.cursor.find_slice(changes, slots) {
             Some(v) => v,
             None => return Slice::new(slots.end, slots.end),
         };

--- a/src/query/borrow.rs
+++ b/src/query/borrow.rs
@@ -71,10 +71,12 @@ where
             new_tick: self.new_tick,
         };
 
+        let prepared_fetch = self.fetch.prepare(data);
+
         Some(PreparedArchetype {
             arch_id,
             arch,
-            fetch: self.fetch.prepare(data)?,
+            fetch: prepared_fetch?,
         })
     }
 }

--- a/src/query/planar.rs
+++ b/src/query/planar.rs
@@ -201,9 +201,8 @@ where
 
             if let Some(mut p) = self.state.prepare_fetch(arch_id, arch) {
                 let chunk = p.chunks();
-
                 for item in chunk.flatten() {
-                    func(item)
+                    func(item);
                 }
             }
         }

--- a/src/world.rs
+++ b/src/world.rs
@@ -267,7 +267,7 @@ impl World {
             .get_disjoint(arch_id, self.archetypes.root)
             .unwrap();
 
-        let (dst_slot, swapped) = unsafe { src.move_to(dst, slot, |c, p| c.drop(p)) };
+        let (dst_slot, swapped) = unsafe { src.move_to(dst, slot, 0, |c, p| c.drop(p)) };
 
         if let Some((swapped, slot)) = swapped {
             // The last entity in src was moved into the slot occupied by id
@@ -308,7 +308,7 @@ impl World {
 
         let (src, dst) = self.archetypes.get_disjoint(loc.arch_id, dst_id).unwrap();
 
-        let (dst_slot, swapped) = unsafe { src.move_to(dst, loc.slot, |c, p| c.drop(p)) };
+        let (dst_slot, swapped) = unsafe { src.move_to(dst, loc.slot, 0, |c, p| c.drop(p)) };
 
         if let Some((swapped, slot)) = swapped {
             // The last entity in src was moved into the slot occupied by id
@@ -367,10 +367,13 @@ impl World {
         //     panic!("Attempt to despawn static component");
         // }
 
+        // Advance the change tick to record the removal
+        let change_tick = self.advance_change_tick();
+
         let src = self.archetypes.get_mut(arch);
 
         let swapped = unsafe {
-            src.take(slot, |c, p| {
+            src.take(slot, change_tick, |c, p| {
                 c.drop(p);
             })
         };
@@ -640,6 +643,10 @@ impl World {
         };
 
         assert_ne!(src_id, dst_id);
+        
+        // Advance the change tick to record the removal
+        let change_tick = self.advance_change_tick();
+        
         // Borrow disjoint
         let (src, dst) = self.archetypes.get_disjoint(src_id, dst_id).unwrap();
         src.add_incoming(desc.key(), dst_id);
@@ -651,7 +658,7 @@ impl World {
 
         // Capture the ONE moved value
         let mut on_drop = Some(on_drop);
-        let (dst_slot, swapped) = src.move_to(dst, slot, |_, p| {
+        let (dst_slot, swapped) = src.move_to(dst, slot, change_tick, |_, p| {
             let drop = on_drop.take().expect("On drop called more than once");
             (drop)(p);
         });
@@ -1261,7 +1268,7 @@ impl World {
             // Take each entity one by one and append them to the world
             if arch.has(is_static_entity().key()) {
                 while let Some(id) = unsafe {
-                    arch.pop_last(|mut desc, ptr| {
+                    arch.pop_last(0, |mut desc, ptr| {
                         let key = &mut desc.key;
 
                         // Modify the relations to match new components

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -150,7 +150,7 @@ unsafe impl<W: ComponentUpdater + ComponentPusher> EntityWriter for SingleCompon
             (src, dst, dst_id)
         };
 
-        let (dst_slot, swapped) = unsafe { src.move_to(dst, src_loc.slot, |c, ptr| c.drop(ptr)) };
+        let (dst_slot, swapped) = unsafe { src.move_to(dst, src_loc.slot, tick, |c, ptr| c.drop(ptr)) };
 
         // Insert the missing component
         let pushed = unsafe {
@@ -445,7 +445,7 @@ unsafe impl EntityWriter for Buffered<'_> {
             .get_disjoint(src_loc.arch_id, dst_id)
             .unwrap();
 
-        let (dst_slot, swapped) = unsafe { src.move_to(dst, src_loc.slot, |c, ptr| c.drop(ptr)) };
+        let (dst_slot, swapped) = unsafe { src.move_to(dst, src_loc.slot, tick, |c, ptr| c.drop(ptr)) };
 
         // Insert the missing components
         for (desc, src) in self.buffer.drain() {

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -358,3 +358,89 @@ fn entity_filter() {
 
     assert_eq!(query.borrow(&world).iter().sorted().collect_vec(), expected);
 }
+
+#[test]
+fn removed_filter_simple() {
+    let mut world = World::new();
+
+    component! {
+        value: i32,
+        temp: String,
+    }
+
+    // Create an entity with components
+    let id1 = Entity::builder()
+        .set(value(), 10)
+        .set(temp(), "first".to_string())
+        .spawn(&mut world);
+
+    // Create a query for removed components using .with_filter()
+    let mut query = Query::new((entity_ids(), value().cloned())).with_filter(temp().removed());
+
+    eprintln!("Before removal, querying entities...");
+    let result = query.borrow(&world).iter().collect_vec();
+    eprintln!("Result: {:?}", result);
+    assert_eq!(result.len(), 0, "Should be no entities with removed components before removal");
+    
+    // Remove temp component from id1
+    world.remove(id1, temp()).unwrap();
+
+    eprintln!("After removal, querying entities...");
+    let result = query.borrow(&world).iter().collect_vec();
+    eprintln!("Result: {:?}", result);
+    assert_eq!(result.len(), 1, "Should be one entity with removed component after removal");
+    assert_eq!(result[0].0, id1, "Should be the entity we removed the component from");
+    assert_eq!(result[0].1, 10, "Should have the value component intact");
+
+    eprintln!("Rerunning query should give 0 change now...");
+    let result = query.borrow(&world).iter().collect_vec();
+    eprintln!("Result: {:?}", result);
+    assert_eq!(result.len(), 0, "Should be one entity with removed component after removal");
+}
+
+#[test]
+fn removed_filter_on_despawn() {
+    let mut world = World::new();
+
+    component! {
+        health: i32,
+        armor: String,
+    }
+
+    // Create entities with components
+    let id1 = Entity::builder()
+        .set(health(), 100)
+        .set(armor(), "steel".to_string())
+        .spawn(&mut world);
+
+    let id2 = Entity::builder()
+        .set(health(), 50)
+        .set(armor(), "leather".to_string())
+        .spawn(&mut world);
+
+    // Create a query for removed armor components
+    let mut query = Query::new((entity_ids(), health().cloned())).with_filter(armor().removed());
+
+    eprintln!("Before despawn, querying entities...");
+    let result = query.borrow(&world).iter().collect_vec();
+    eprintln!("Result: {:?}", result);
+    assert_eq!(result.len(), 0, "Should be no entities with removed components before despawn");
+    
+    // Despawn entity id1 - this should trigger removal events for all its components
+    world.despawn(id1).unwrap();
+
+    eprintln!("After despawn, querying entities...");
+    let result = query.borrow(&world).iter().collect_vec();
+    eprintln!("Result: {:?}", result);
+    
+    // DESIGN DECISION: After despawn, the entity no longer exists in the world.
+    // Even though removal events are recorded (with proper change ticks now),
+    // there's no entity to return in query results since the entity is completely gone.
+    // This is the correct behavior - despawned entities can't appear in any query.
+    // The removal events are still recorded for consistency and potential event systems.
+    assert_eq!(result.len(), 0, "Despawned entities cannot appear in queries (they don't exist)");
+    
+    // Verify id2 is still alive and unaffected
+    assert!(world.is_alive(id2), "Other entities should remain unaffected");
+    assert!(!world.is_alive(id1), "Despawned entity should no longer be alive");
+}


### PR DESCRIPTION
I saw that removal wasn't implemented, so thought I'd give a crack with claude. I am not 100% sure this is the best way for it, since I am not familiar with ECS internals. 